### PR TITLE
微信小程序调用远程接口时，返回结果会额外多包裹一层data

### DIFF
--- a/utils/sdk/src/connection.js
+++ b/utils/sdk/src/connection.js
@@ -774,7 +774,7 @@ connection.prototype.open = function (options) {
         var suc = function (data, xhr, myName) {
             // console.log('success',data, xhr, myName)
             conn.context.status = _code.STATUS_DOLOGIN_IM;
-            conn.context.restTokenData = data;
+            conn.context.restTokenData = data.data;
             //console.log(options)
             if (data.statusCode != '404' && data.statusCode != '400') {
                 wx.showToast({


### PR DESCRIPTION
微信小程序调用远程接口时，返回结果会额外多包裹一层data。这个改动可以修复原先的reconnect失败的bug。